### PR TITLE
Add StaticFuzz to Geolocation & Maps OSINT

### DIFF
--- a/osint-tools/staticfuzz.md
+++ b/osint-tools/staticfuzz.md
@@ -1,0 +1,94 @@
+---
+description: >-
+  Tool Description: A forensic analysis platform that ingests raw GPS and lat/lng
+  CSV data and produces a court-admissible PDF intelligence report in under four
+  minutes using Haversine velocity analysis and movement timeline reconstruction.
+---
+
+# StaticFuzz
+
+| **StaticFuzz**   | **Quick Overview**                                                                                                             |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| URL              | [https://staticfuzz.online/](https://staticfuzz.online/)                                                                       |
+| What it does     | Analyses raw GPS/lat/lng CSV data to produce sealed, court-admissible PDF reports with Haversine velocity analysis and movement timelines. |
+| How to use it    | Import a CSV of lat/lng/timestamp records; StaticFuzz processes locally and outputs a SHA-256 sealed PDF report.               |
+| Cost             | Paid (perpetual license, no subscription).                                                                                     |
+| Account required | No.                                                                                                                            |
+| Cookies          | None (fully offline desktop application).                                                                                      |
+| Ownership        | Developed by Nils Lilja.                                                                                                       |
+| Use in Reporting | Produces ISO/IEC 27037:2012 compliant evidence reports suitable for legal proceedings, court submissions, and SIU investigations. |
+
+### What does StaticFuzz do?
+
+StaticFuzz is a local, zero-cloud forensic intelligence platform for investigators working with GPS and location data. It ingests raw lat/lng/timestamp CSV files, runs Haversine velocity analysis, reconstructs movement timelines, flags anomalies, and outputs a fully sealed PDF report.
+
+**The lowdown:** It replaces 20+ hours of manual location evidence analysis with a four-minute automated workflow that produces court-admissible output with a complete SHA-256 audit trail.
+
+### How to Use
+
+**1. Import your GPS/lat/lng CSV data file.**
+
+**2. StaticFuzz performs Haversine velocity analysis and movement reconstruction locally on your device.**
+
+**3. Export the sealed, court-admissible PDF intelligence report.**
+
+All processing happens offline. No data leaves the machine.
+
+### Cost
+
+* [ ] Free
+* [ ] Partially Free
+* [x] Paid
+
+Perpetual license. No subscription, no cloud fees.
+
+## Data Processing
+
+### Account Required:
+
+* [ ] Yes
+* [x] No
+
+### Cookies:
+
+None. The application runs entirely offline with no web components.
+
+### Use in Reporting
+
+StaticFuzz is built for:
+
+* Court submissions requiring ISO/IEC 27037:2012 compliant evidence reports.
+* Insurance SIU investigations involving location alibi verification.
+* Private investigation cases with GPS/movement evidence.
+* Digital forensics casework requiring sealed, auditable output.
+
+| **Capabilities**                              | **Limitations**                                            |
+| --------------------------------------------- | ---------------------------------------------------------- |
+| Haversine velocity analysis on raw CSV data.  | Requires structured lat/lng/timestamp CSV input.           |
+| Movement timeline reconstruction.             | Desktop application (not browser-based).                   |
+| ISO/IEC 27037:2012 compliant PDF output.      | Paid license required.                                     |
+| SHA-256 sealed audit trail.                   | Single-device perpetual license.                           |
+| Fully offline, zero-cloud architecture.       |                                                            |
+
+### Summary
+
+StaticFuzz is a purpose-built forensic tool for investigators who need to turn raw GPS data into court-ready evidence quickly and defensibly. Its offline architecture and sealed output make it suitable for professional legal and insurance investigation workflows.
+
+### Ownership
+
+Developed by Nils Lilja.
+
+### Ethical Considerations
+
+* Authorised professional use only; valid forensic credentials required.
+* Not intended for surveillance or tracking of individuals without lawful authority.
+
+### Related Tools
+
+* Cellebrite UFED (mobile device forensics)
+* Oxygen Forensic Detective
+* Google Earth Pro
+
+#### Sources
+
+[https://staticfuzz.online/](https://staticfuzz.online/)

--- a/tool-categories/geolocation-and-maps-osint.md
+++ b/tool-categories/geolocation-and-maps-osint.md
@@ -13,3 +13,4 @@ Geolocation & Maps OSINT focuses on identifying locations and analyzing geograph
 | GeoSpy                          | [Find out more](../osint-tools/geospy.md)                          |
 | Surveillance under Surveillance | [Find out more](../osint-tools/surveillance-under-surveillance.md) |
 | MW Geofind                      | [Find out more](../osint-tools/mw-geofind.md)                      |
+| StaticFuzz                      | [Find out more](../osint-tools/staticfuzz.md)                      |


### PR DESCRIPTION
## Tool Submission: StaticFuzz

**Category:** Geolocation & Maps OSINT

**URL:** https://staticfuzz.online/

**Description:** StaticFuzz is a forensic analysis platform that ingests raw GPS/lat/lng CSV data and produces a court-admissible PDF intelligence report in under four minutes. It runs Haversine velocity analysis, reconstructs movement timelines, and outputs a SHA-256 sealed report with a complete audit trail.

**Why it belongs here:**
- Purpose-built for investigators working with GPS and location evidence
- ISO/IEC 27037:2012 compliant output (court-admissible)
- Fully offline, zero-cloud architecture — appropriate for sensitive casework
- Used in SIU fraud investigations, private investigation, and digital forensics

**Changes made:**
- Added `osint-tools/staticfuzz.md` with full tool entry in the standard format
- Added StaticFuzz to `tool-categories/geolocation-and-maps-osint.md`

I followed the submission guide format based on existing entries like `geospy.md`.