### PR TITLE
Add Lullar — free people-search across 170+ platforms

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -173,4 +173,5 @@
   * [Shodan](osint-tools/shodan.md)
   * [Dune](osint-tools/dune.md)
   * [Filmot](osint-tools/filmot.md)
+  * [Lullar](osint-tools/lullar.md)
 * [Submission Guide](submission-guide.md)

--- a/osint-tools/lullar.md
+++ b/osint-tools/lullar.md
@@ -1,0 +1,94 @@
+---
+description: >-
+  Tool Description : A free people-search engine that checks a username, email,
+  or name across 170+ social media and online platforms in one query.
+---
+
+# Lullar
+
+| **Lullar**       | **Quick Overview**                                                                                                              |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| URL              | [https://com.lullar.com](https://com.lullar.com)                                                                              |
+| What it does     | Searches a username, email address, or name across 170+ social, messaging, gaming, dating, and developer platforms at once.   |
+| How to use it    | Enter a username, email, or name and review the direct profile links returned for each platform.                              |
+| Cost             | Free.                                                                                                                          |
+| Account required | No.                                                                                                                            |
+| Cookies          | Standard usability and analytics cookies.                                                                                      |
+| Ownership        | Independently operated people-search service, online since 2008.                                                              |
+| Use in Reporting | Useful for fast username/email enumeration and mapping a subject's cross-platform presence during early reconnaissance.       |
+
+### What does Lullar do?
+
+Lullar is a browser-based people-search and username-enumeration tool. You give it a username, email address, or name and it generates direct search/profile links across 170+ platforms — social media (Instagram, TikTok, X, Facebook, Reddit), messaging, gaming (Steam, Twitch, Roblox), dating, developer (GitHub), and a number of regional/non-English sites (VK, OK.ru, Weibo, Mail.ru). It runs entirely in the browser with no install or sign-up, and the interface is localized into 22 languages.
+
+**The lowdown:** Lullar is a quick, no-friction first pass for username and email reconnaissance — handy when you can't install CLI tooling or just want to map a subject's footprint in seconds, before going deeper with tools like Sherlock, Maigret, or Holehe.
+
+### How to Use:
+
+**1. Go to** [**https://com.lullar.com**](https://com.lullar.com) **and enter a username, email address, or name.**
+
+**2. Review the returned direct links per platform and open the ones relevant to your investigation.**
+
+**3. Pivot — a reused username on one platform often leads to more accounts elsewhere; feed findings into deeper tools or a reverse-image search.**
+
+### Cost
+
+* [x] Free
+* [ ] Partially Free
+* [ ] Paid
+
+Free to use, no account required.
+
+## Data Processing
+
+### Account Required:
+
+* [ ] Yes
+* [x] No
+
+### Cookies:
+
+Standard usability and analytics cookies.
+
+### Use in Reporting
+
+Lullar can support:
+
+* Username enumeration across many platforms.
+* Email-to-account correlation (it also searches the email's username portion).
+* Mapping a subject's cross-platform presence.
+* Early-stage reconnaissance and pivoting.
+
+| **Capabilities**                                          | **Limitations**                                          |
+| --------------------------------------------------------- | -------------------------------------------------------- |
+| Searches 170+ platforms from one query.                   | Surfaces public profiles only; does not access private data. |
+| Username, email, and name input.                          | Results depend on each platform's own public search.     |
+| Includes regional/non-English platforms many tools skip.  | Can produce false positives — verify matches.            |
+| No install, no sign-up, 22 languages.                     | Not a background-check / public-records service.          |
+| Fast pivoting between identifiers.                         |                                                          |
+
+### Summary
+
+Lullar is best for the collection and correlation stages of the OSINT workflow — a fast, accessible way to turn a single identifier into multiple cross-platform leads. As with any enumeration tool, confirm matches with a second source.
+
+### Ownership
+
+Lullar is an independently operated people-search service that has been online since 2008.
+
+### Ethical Considerations
+
+* Only investigate data you are authorised to.
+* Be mindful of privacy laws in your jurisdiction.
+* Verify results before relying on them.
+* Do not use findings for harassment or for decisions regulated by laws such as the FCRA (employment, housing, credit).
+
+### Related Tools:
+
+* [Epieos](epieos.md)
+* Sherlock
+* Maigret
+* Holehe
+
+#### Sources
+
+[https://com.lullar.com](https://com.lullar.com)


### PR DESCRIPTION
Adds **[Lullar](https://com.lullar.com)** to the OSINT Tools Library.

**What it is:** a free, browser-based people-search / username-enumeration tool. Enter a username, email, or name and it returns direct profile links across 170+ social, messaging, gaming, dating, and developer platforms in one query.

**Why it fits the library:**
- Free, no install, no sign-up — usable for quick reconnaissance on any machine
- Username + email + name input (also searches the email's username portion)
- Includes regional/non-English platforms (VK, OK.ru, Weibo, Mail.ru) that many enumeration tools skip
- Online since 2008; interface localized into 22 languages
- Complements CLI tools like Sherlock/Maigret/Holehe for a fast first pass

**Changes:** added `osint-tools/lullar.md` (full tool page in the existing template format) + a `SUMMARY.md` entry. No other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)