### PR TITLE
Add Fylings — African company-registry search & verification

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -67,6 +67,7 @@
   * [Corp Watch](osint-tools/corp-watch.md)
   * [Corporation Wiki](osint-tools/corporation-wiki.md)
   * [OpenCorporates](osint-tools/opencorporates.md)
+  * [Fylings](osint-tools/fylings.md)
   * [GrayhatWarfare](osint-tools/grayhatwarfare.md)
   * [Bitcoin Whoswho](osint-tools/bitcoin-whoswho.md)
   * [Jimpl](osint-tools/jimpl.md)

--- a/osint-tools/fylings.md
+++ b/osint-tools/fylings.md
@@ -1,0 +1,107 @@
+---
+description: >-
+  Tool Description : A free company-intelligence platform for Africa that lets
+  you search and verify companies across 18+ official national registries, with
+  the official source and a last-verified date on every record.
+---
+
+# Fylings
+
+| **Fylings**      | **Quick Overview**                                                                                                                                                                        |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| URL              | [https://www.fylings.com/](https://www.fylings.com/)                                                                                                                                    |
+| What it does     | Aggregates official company-registry data from 18+ African countries into one searchable platform, showing the source registry and a last-verified date on every record.                |
+| How to use it    | Search by company name or registration number, filter by country, and open a company profile to see registry details, beneficial ownership, government contracts, and sanctions checks. |
+| Cost             | Free (search and company profiles). Deeper ownership reports and API are paid.                                                                                                          |
+| Account required | No.                                                                                                                                                                                     |
+| Cookies          | Minimal.                                                                                                                                                                                |
+| Ownership        | Fylings (Serene Circle LLC).                                                                                                                                                             |
+| Use in Reporting | Useful for cross-border due diligence, KYB/onboarding, supplier vetting, and tracing companies and directors across African jurisdictions where registries are otherwise fragmented.    |
+
+### What does Fylings do?
+
+Africa's company registries are fragmented, often hard to search, and rarely comparable across borders. Fylings pulls the public registers of 18+ African countries into a single searchable layer — Nigeria's CAC, Tanzania's BRELA, Mauritius's CBRD, Senegal's RCCM, Zambia's PACRA, Ghana's ORC, Uganda's URSB and more — and normalises them into one schema.
+
+Its distinguishing feature for investigators is **provenance**: every record shows which official registry it came from and when it was last verified, and blank fields are left blank rather than guessed.
+
+**The lowdown:** it won't replace a certified registry extract, but it's the fastest way to check whether an African company is real, active, and who is behind it — across many countries at once.
+
+Data available includes:
+
+* Company status (active, dissolved, etc.), legal form, and incorporation date
+* Registration number and official registry source
+* Directors and beneficial owners (persons with significant control), where the register publishes them
+* Government-contract awards (from open-contracting data)
+* Sanctions and watchlist screening (OFAC, UN)
+
+### How to Use:
+
+1. **Go to fylings.com and search by company name or registration number, optionally filtering by country.**
+2. **Open a company profile to review its registry source, last-verified date, status, directors/ownership, government contracts, and sanctions screening.**
+3. **Verify anything material against the primary registry before relying on it — Fylings links back to the official source on each record.**
+
+### Cost:
+
+* [ ] Paid
+* [x] Partially Free
+* [ ] Free
+
+_Search and company profiles are free; deeper beneficial-ownership reports and the API are paid._
+
+## Data Processing
+
+### Account required:
+
+* [ ] Yes
+* [x] No
+
+### Cookies:
+
+Minimal cookies for basic site functionality.
+
+### Use in Reporting
+
+Fylings can support:
+
+* Cross-border corporate due diligence in Africa
+* KYB / onboarding and supplier vetting
+* Beneficial-ownership and director-network mapping
+* Government-procurement and vendor investigations
+* Sanctions and watchlist checks
+
+It is typically used alongside tools such as OpenCorporates, OCCRP Aleph, and OpenSanctions, filling the African-registry coverage gap those tools have.
+
+| **Capabilities**                                                              | **Limitations**                                                                 |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Searches 18+ official African national company registries from one interface. | Coverage varies by country; some registries publish fewer fields than others.   |
+| Shows the source registry and a last-verified date on every record.           | Not a certified/legal extract — verify material facts against the primary source. |
+| Surfaces beneficial ownership where the register publishes it.                | Deeper ownership reports and the API are paid.                                   |
+| Includes government-contract awards and sanctions screening.                  | Registry data is self-reported by companies, so accuracy may vary.              |
+| Free MCP server and API for programmatic access.                              | <p><br></p>                                                                     |
+
+### Summary
+
+Fylings is a practical starting point for African corporate intelligence: free search across many national registries, provenance on every record, and enrichment (ownership, government contracts, sanctions) that individual registries rarely offer. It is best used in the discovery and verification stages of an investigation, with primary registries used to confirm findings.
+
+### Ownership
+
+Fylings is operated by Serene Circle LLC. It exposes a free, no-key MCP server ([https://www.fylings.com/api/mcp](https://www.fylings.com/api/mcp)) and an API for programmatic access.
+
+### Ethical Considerations:
+
+* Handle personal information (directors, beneficial owners) responsibly and in line with data-protection law.
+* Treat registry data as self-reported; verify before drawing conclusions.
+* Use the official source link on each record for anything material.
+
+### Related Tools:
+
+* OpenCorporates
+* OCCRP Aleph
+* OpenSanctions
+* Companies House
+
+#### Sources:
+
+[https://www.fylings.com/](https://www.fylings.com/)
+
+[https://www.fylings.com/about](https://www.fylings.com/about)


### PR DESCRIPTION
Adds a new tool page for **Fylings** (`osint-tools/fylings.md`) and registers it in `SUMMARY.md` next to OpenCorporates.

Fylings is a free platform that searches and verifies companies across **18+ official African national registries** (Nigeria's CAC, Tanzania's BRELA, Mauritius's CBRD, Senegal's RCCM, Zambia's PACRA, Ghana's ORC, Uganda's URSB and more), showing the official registry source and a last-verified date on every record. It also surfaces beneficial ownership, government-contract awards, and OFAC/UN sanctions screening, and exposes a free MCP server + API.

It fills the African-registry coverage gap that OpenCorporates, OCCRP Aleph, and OpenSanctions leave, and is a natural companion to them for cross-border due diligence.

- Page follows the existing tool template (quick-overview table, how-to, cost/data-processing checkboxes, capabilities/limitations, related tools, sources).
- No screenshots included — happy to add `.gitbook/assets` images if you'd like them.

Site: https://www.fylings.com