### PR TITLE
Add THINKPOL (Reddit) to the OSINT Tools Library

### DIFF
--- a/osint-tools/thinkpol.md
+++ b/osint-tools/thinkpol.md
@@ -1,0 +1,38 @@
+---
+description: >-
+  Tool Description : Free Reddit OSINT tools backed by a 30-billion-post archive
+  including deleted and removed content - user lookup, deleted-post viewer,
+  subreddit intelligence, and archive search.
+---
+
+# THINKPOL
+
+| **THINKPOL**     | **Quick Overview**                                                                                                                                                        |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| URL              | [think-pol.com/tools](https://think-pol.com/tools)                                                                                                                        |
+| What it does     | Surfaces Reddit posts and comments already deleted or removed, and profiles users and subreddits, using a 30-billion-post historical archive rather than the live API.    |
+| How to use it    | Pick a tool (user lookup, deleted-post viewer, subreddit intelligence, or archive search), enter a Reddit username, subreddit, or keyword, and review the results.        |
+| Cost             | Free - the tools require no signup. A paid API is available for professional use.                                                                                         |
+| Account required | No - the free tools work without an account.                                                                                                                             |
+| Cookies          | Standard website cookies for functionality and analytics.                                                                                                                |
+| Ownership        | THINKPOL SAS, an EU-based (France) intelligence company.                                                                                                                  |
+| Use in Reporting | Recovers deleted or removed Reddit content and reconstructs user and subreddit activity, useful for OSINT investigations, fraud, and threat intelligence.                 |
+
+### **What does THINKPOL do?**
+
+THINKPOL provides a set of free Reddit OSINT tools backed by a private archive of over 30 billion Reddit posts and comments, including content that has since been deleted by users or removed by moderators.
+
+The free tools include:
+
+* Reddit User Lookup - a behavioural profile of any Reddit account from its full public history
+* View Deleted Reddit Posts - retrieve posts and comments removed from the live site that the archive captured before deletion
+* Subreddit Intelligence - who drives a community, its moderators, and trending content
+* Reddit Archive Search - full-text search across the archive, including deleted and removed content
+
+**The lowdown:** because it relies on a historical archive rather than Reddit's live API, THINKPOL can return content that tools such as Reveddit and Pushshift-based services can no longer recover after Reddit's 2023 API changes. It is EU-hosted and GDPR-aligned.
+
+### How to Use:
+
+1. **Go to** [**think-pol.com/tools**](https://think-pol.com/tools) **and choose a tool.**
+2. **Enter a Reddit username, subreddit, or keyword.**
+3. **Review the results, including archived and deleted posts and comments.**

--- a/tool-categories/social-media-osint/reddit.md
+++ b/tool-categories/social-media-osint/reddit.md
@@ -6,4 +6,4 @@
 | Subreddits.org              | [Find out more](../../osint-tools/subreddits.org.md)             |
 | Subreddit Stats             | [Find out more](../../osint-tools/subreddit-stats.md)            |
 | Aware Online: Reddit Search | [Find out more](../../osint-tools/aware-online-reddit-search.md) |
-
+| THINKPOL                    | [Find out more](../../osint-tools/thinkpol.md)                   |


### PR DESCRIPTION
Adds THINKPOL under Social Media OSINT > Reddit, with a tool deep-dive page matching the existing template plus a row in the Reddit category. Disclosure: I work for THINKPOL. It offers free Reddit OSINT tools (user lookup, deleted/removed-post viewer, subreddit intelligence, archive search) backed by a large historical archive, useful for recovering content removed after Pushshift's shutdown. Happy to adjust formatting or add screenshots if preferred (also available via your Submit-a-Tool form).