### PR TITLE
Add Metadata Remover tool entry

### DIFF
--- a/osint-tools/metadata-remover.md
+++ b/osint-tools/metadata-remover.md
@@ -1,0 +1,86 @@
+---
+description: >-
+  Tool Description: Browser-based image metadata viewer and remover that
+  processes supported images locally on the user's device.
+---
+
+# Metadata Remover
+
+| **Metadata Remover** | **Quick Overview** |
+| --- | --- |
+| URL | [https://metadataremover.ai/metadata-viewer](https://metadataremover.ai/metadata-viewer) |
+| What it does | Displays embedded metadata in JPG, PNG and WebP images and lets users export cleaned copies. Processing happens locally in the browser. |
+| How to use it | Select or drop an image, review detected fields, and optionally download a cleaned copy. |
+| Cost | Free |
+| Account required | No |
+| Cookies | The tool works without an account. Users should independently review the current privacy and cookie information before handling sensitive material. |
+| Ownership | Metadata Remover is maintained by Leo Song. |
+| Use in Reporting | Useful for inspecting image metadata as a supporting signal and for reducing accidental metadata disclosure in working copies. |
+
+## What does Metadata Remover do?
+
+Metadata Remover reads embedded metadata from supported image files in the browser. It can show fields such as EXIF, GPS, XMP and IPTC data and can create a cleaned export. The selected image is processed locally rather than uploaded to Metadata Remover.
+
+Metadata can provide leads about a file, but it may be missing, modified or stripped by platforms. It does not prove authenticity or authorship on its own.
+
+## How to Use
+
+1. Open [Metadata Viewer](https://metadataremover.ai/metadata-viewer).
+2. Select or drop a JPG, PNG or WebP image.
+3. Review the detected metadata fields.
+4. If needed, export a cleaned copy and verify that the required metadata was removed.
+5. Preserve the original evidence file separately.
+
+## Cost
+
+* [ ] Paid
+* [ ] Partially Free
+* [x] Free
+
+## Data Processing
+
+### Account required
+
+* [ ] Yes
+* [x] No
+
+### Cookies and privacy
+
+The image is processed locally in the browser and is not uploaded to Metadata Remover. Investigators should still review the site's current privacy information and use an appropriate evidence-handling workflow.
+
+## Use in Reporting
+
+Metadata Remover can support the initial inspection of image metadata and help create reduced-metadata copies for collaboration or publication. Findings should be corroborated with source verification, reverse image search, geolocation, chronolocation and other investigative methods.
+
+| **Capabilities** | **Limitations** |
+| --- | --- |
+| Displays embedded metadata from supported image formats. | Supports JPG, PNG and WebP images; it is not a general file-forensics suite. |
+| Processes selected images locally in the browser. | Metadata may be absent, edited or removed by messaging and social platforms. |
+| Can export a cleaned image copy. | Metadata cannot independently prove authenticity, authorship or capture context. |
+| Requires no account. | Investigators should preserve original evidence and verify cleaned exports. |
+
+## Summary
+
+Metadata Remover is a free, browser-based option for viewing image metadata and exporting reduced-metadata copies. Its local-processing design can be useful for privacy-sensitive workflows, but results require corroboration and should not be treated as a forensic conclusion.
+
+## Ownership
+
+Metadata Remover is maintained by Leo Song. This entry was submitted by the maintainer and should be reviewed independently by the library editors.
+
+## Ethical Considerations
+
+* Preserve original evidence before removing metadata.
+* Avoid definitive authenticity or authorship claims based on metadata alone.
+* Consider privacy, consent and potential harm when handling personal images or location data.
+* Document the inspection and export process when results are used in reporting.
+
+## Related Tools
+
+* ExifTool
+* Jimpl
+* MW Metadata
+
+## Sources
+
+* [Metadata Viewer](https://metadataremover.ai/metadata-viewer)
+* [Metadata Remover privacy information](https://metadataremover.ai/privacy)


### PR DESCRIPTION
## Summary

- adds a factual Metadata Remover tool page using the library's existing detailed-entry structure
- documents browser-local image processing, supported formats, account/cost details, and privacy characteristics
- states that metadata is only a supporting signal and cannot prove authenticity or authorship
- includes preservation and ethical-use guidance

## Disclosure

I maintain Metadata Remover, so this is an affiliated resource contribution. I have kept the entry factual and included limitations so it can be reviewed independently.